### PR TITLE
Support collections

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,5 @@
 Todo:
+  ☐ Create ReactView (Marionette)
   ☐ Add Storybook for examples
   ☐ Utilize context to support `actions`
   ☐ Support custom triggers to force getting new props for internal state

--- a/TODO
+++ b/TODO
@@ -1,5 +1,4 @@
 Todo:
   ☐ Add Storybook for examples
-  ☐ Support `collections` in `data`
   ☐ Utilize context to support `actions`
   ☐ Support custom triggers to force getting new props for internal state

--- a/TODO
+++ b/TODO
@@ -2,3 +2,5 @@ Todo:
   ☐ Add Storybook for examples
   ☐ Utilize context to support `actions`
   ☐ Support custom triggers to force getting new props for internal state
+  ☐ Customize events that trigger recomputing state
+  ☐ Memoize selector

--- a/src/components/EnhancedComponent/EnhancedComponent.js
+++ b/src/components/EnhancedComponent/EnhancedComponent.js
@@ -1,10 +1,14 @@
 import React, {Component} from 'react'
-import {getModels, transformDataToProps} from './util'
+import {getCollections, getModels, transformDataToProps} from './util'
+
+const COLLECTION_EVENTS = 'add change remove reset'
+const MODEL_EVENTS = 'change'
 
 class EnhancedComponent extends Component {
   constructor(props) {
     super(props)
     this.state = this.getPropsForState()
+    this.collections = getCollections(props.data)
     this.models = getModels(props.data)
   }
 
@@ -35,14 +39,20 @@ class EnhancedComponent extends Component {
   }
 
   unwatch() {
+    this.collections.forEach(collection => {
+      collection.off(COLLECTION_EVENTS, this.updatePropsInState, this)
+    })
     this.models.forEach(model => {
-      model.off('change', this.updatePropsInState, this)
+      model.off(MODEL_EVENTS, this.updatePropsInState, this)
     })
   }
 
   watch() {
+    this.collections.forEach(collection => {
+      collection.on(COLLECTION_EVENTS, this.updatePropsInState, this)
+    })
     this.models.forEach(model => {
-      model.on('change', this.updatePropsInState, this)
+      model.on(MODEL_EVENTS, this.updatePropsInState, this)
     })
   }
 }

--- a/src/components/EnhancedComponent/__tests__/EnhancedComponent.test.js
+++ b/src/components/EnhancedComponent/__tests__/EnhancedComponent.test.js
@@ -6,6 +6,16 @@ import {mount} from 'enzyme'
 describe('EnhancedComponent', () => {
   const Button = ({label}) => <button>{label}</button>
 
+  test('should listen for changes on collections when the component mounts', () => {
+    const component = <Button label="Click Me" />
+    const data = {
+      collection: new Backbone.Collection([]),
+    }
+    data.collection.on = jest.fn()
+    mount(<EnhancedComponent component={component} data={data} />)
+    expect(data.collection.on).toHaveBeenCalled()
+  })
+
   test('should listen for changes on models when the component mounts', () => {
     const component = <Button label="Click Me" />
     const data = {
@@ -14,6 +24,17 @@ describe('EnhancedComponent', () => {
     data.model.on = jest.fn()
     mount(<EnhancedComponent component={component} data={data} />)
     expect(data.model.on).toHaveBeenCalled()
+  })
+
+  test('should stop listening for changes on collections when the component unmounts', () => {
+    const component = <Button label="Click Me" />
+    const data = {
+      collection: new Backbone.Collection([]),
+    }
+    data.collection.off = jest.fn()
+    const c = mount(<EnhancedComponent component={component} data={data} />)
+    c.unmount()
+    expect(data.collection.off).toHaveBeenCalled()
   })
 
   test('should stop listening for changes on models when the component unmounts', () => {
@@ -25,6 +46,106 @@ describe('EnhancedComponent', () => {
     const c = mount(<EnhancedComponent component={component} data={data} />)
     c.unmount()
     expect(data.model.off).toHaveBeenCalled()
+  })
+
+  test('should update the state when the collection is added to', () => {
+    const component = <Button />
+    const data = {
+      collection: new Backbone.Collection([]),
+    }
+    const selector = ({collection}) => {
+      return {
+        label: collection.map(m => m.name).join(' '),
+      }
+    }
+    const c = mount(
+      <EnhancedComponent
+        component={component}
+        data={data}
+        selector={selector}
+      />,
+    )
+    expect(c.state('label')).toEqual('')
+    data.collection.add(new Backbone.Model({name: 'hello'}))
+    expect(c.state('label')).toEqual('hello')
+    data.collection.add(new Backbone.Model({name: 'world'}))
+    expect(c.state('label')).toEqual('hello world')
+  })
+
+  test('should update the state when models are changed in the collection', () => {
+    const component = <Button />
+    const model1 = new Backbone.Model({id: 1, name: 'hello'})
+    const model2 = new Backbone.Model({id: 2, name: 'world'})
+    const data = {
+      collection: new Backbone.Collection([model1, model2]),
+    }
+    const selector = ({collection}) => {
+      return {
+        label: collection.map(m => m.name).join(' '),
+      }
+    }
+    const c = mount(
+      <EnhancedComponent
+        component={component}
+        data={data}
+        selector={selector}
+      />,
+    )
+    expect(c.state('label')).toEqual('hello world')
+    model1.set('name', 'hey')
+    expect(c.state('label')).toEqual('hey world')
+    model2.set('name', 'you')
+    expect(c.state('label')).toEqual('hey you')
+  })
+
+  test('should update the state when models are removed from the collection', () => {
+    const component = <Button />
+    const model1 = new Backbone.Model({id: 1, name: 'hello'})
+    const model2 = new Backbone.Model({id: 2, name: 'world'})
+    const data = {
+      collection: new Backbone.Collection([model1, model2]),
+    }
+    const selector = ({collection}) => {
+      return {
+        label: collection.map(m => m.name).join(' '),
+      }
+    }
+    const c = mount(
+      <EnhancedComponent
+        component={component}
+        data={data}
+        selector={selector}
+      />,
+    )
+    expect(c.state('label')).toEqual('hello world')
+    data.collection.remove(model2)
+    expect(c.state('label')).toEqual('hello')
+    data.collection.remove(model1)
+    expect(c.state('label')).toEqual('')
+  })
+
+  test('should update the state when the collection is reset', () => {
+    const component = <Button />
+    const data = {
+      collection: new Backbone.Collection([
+        new Backbone.Model({name: 'Click Me'}),
+      ]),
+    }
+    const selector = ({collection}) => {
+      return {
+        label: collection.map(m => m.name).join(' '),
+      }
+    }
+    const c = mount(
+      <EnhancedComponent
+        component={component}
+        data={data}
+        selector={selector}
+      />,
+    )
+    expect(c.state('label')).toEqual('Click Me')
+    data.collection.reset([])
+    expect(c.state('label')).toEqual('')
   })
 
   test('should update the state when the model changes', () => {

--- a/src/components/EnhancedComponent/util/__tests__/getCollections.test.js
+++ b/src/components/EnhancedComponent/util/__tests__/getCollections.test.js
@@ -1,0 +1,36 @@
+import Backbone from 'backbone'
+import {getCollections} from '..'
+
+describe('getCollections', () => {
+  const data = {
+    number: 3,
+    string: 'some string',
+    array: [1, 2, 3],
+    object: {some: 'Object'},
+    model: new Backbone.Model({id: '1'}),
+  }
+
+  test('should return an empty array by default', () => {
+    expect(getCollections()).toEqual([])
+  })
+
+  test('shoudl return an empty array if there are no collections', () => {
+    expect(getCollections(data)).toEqual([])
+  })
+
+  test('should return an array of collections if there are collections', () => {
+    const dataWithCollections = {
+      ...data,
+      collection1: new Backbone.Collection([]),
+      collection2: new Backbone.Collection([
+        new Backbone.Model({id: '2'}),
+        new Backbone.Model({id: '3'}),
+      ]),
+    }
+    const result = getCollections(dataWithCollections)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual(dataWithCollections.collection1)
+    expect(result[1]).toEqual(dataWithCollections.collection2)
+    expect(result[1]).toHaveLength(2)
+  })
+})

--- a/src/components/EnhancedComponent/util/__tests__/getCollections.test.js
+++ b/src/components/EnhancedComponent/util/__tests__/getCollections.test.js
@@ -14,7 +14,7 @@ describe('getCollections', () => {
     expect(getCollections()).toEqual([])
   })
 
-  test('shoudl return an empty array if there are no collections', () => {
+  test('should return an empty array if there are no collections', () => {
     expect(getCollections(data)).toEqual([])
   })
 

--- a/src/components/EnhancedComponent/util/__tests__/getModels.test.js
+++ b/src/components/EnhancedComponent/util/__tests__/getModels.test.js
@@ -7,6 +7,7 @@ describe('getModels', () => {
     string: 'some string',
     array: [1, 2, 3],
     object: {some: 'Object'},
+    collection: new Backbone.Collection([new Backbone.Model({id: 1})]),
   }
 
   test('should return an empty array by default', () => {

--- a/src/components/EnhancedComponent/util/getCollections.js
+++ b/src/components/EnhancedComponent/util/getCollections.js
@@ -1,0 +1,7 @@
+import Backbone from 'backbone'
+
+const getCollections = (data = {}) => {
+  return Object.values(data).filter(val => val instanceof Backbone.Collection)
+}
+
+export default getCollections

--- a/src/components/EnhancedComponent/util/getModels.js
+++ b/src/components/EnhancedComponent/util/getModels.js
@@ -1,9 +1,7 @@
+import Backbone from 'backbone'
+
 const getModels = (data = {}) => {
-  return Object.values(data).filter(value => {
-    return (
-      value && typeof value === 'object' && typeof value.toJSON === 'function'
-    )
-  })
+  return Object.values(data).filter(val => val instanceof Backbone.Model)
 }
 
 export default getModels

--- a/src/components/EnhancedComponent/util/index.js
+++ b/src/components/EnhancedComponent/util/index.js
@@ -1,5 +1,6 @@
-import getModels from "./getModels";
-import transformDataToProps from "./transformDataToProps";
-import transformValueToProp from "./transformValueToProp";
+import getCollections from './getCollections'
+import getModels from './getModels'
+import transformDataToProps from './transformDataToProps'
+import transformValueToProp from './transformValueToProp'
 
-export { getModels, transformDataToProps, transformValueToProp };
+export {getCollections, getModels, transformDataToProps, transformValueToProp}


### PR DESCRIPTION
This PR adds supports for collections such that collections are automatically watched for:

- New models added to collection
- Models removed from the collection
- Models changed within the collection
- The collection being reset

When any of these changes occur, the state is recomputed. This fundamentally works the same as when models are added to the data.