### PR TITLE
Store + Connect

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+package.json
+package-lock.json
+dist/
+coverage/

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,3 @@
+semi: false
+singleQuote: true
+trailingComma: es5

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,3 +1,4 @@
 semi: false
 singleQuote: true
 trailingComma: es5
+bracketSpacing: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -13001,6 +13001,11 @@
         "unist-util-is": "^2.1.2"
       }
     },
+    "unistore": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/unistore/-/unistore-3.1.0.tgz",
+      "integrity": "sha512-odZJeaB7ZDu8pDLOIhUeB5ttcPL6ANtPCua/+rdO31XL++03/zfw6WoQz/tuyqzRhZezCEHT97aV0GJx4dvl6g=="
+    },
     "unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "backbone.cocktail": "^0.5",
     "react": "^15 || ^16",
     "react-dom": "^15 || ^16"
+  },
+  "dependencies": {
+    "unistore": "^3.1.0"
   }
 }

--- a/src/components/EnhancedComponent/__tests__/EnhancedComponent.test.js
+++ b/src/components/EnhancedComponent/__tests__/EnhancedComponent.test.js
@@ -1,10 +1,23 @@
 import Backbone from 'backbone'
 import {EnhancedComponent} from '..'
+import {BrigadeStore} from '../../createStore/createStore'
+import connect from '../../connect'
 import React from 'react'
 import {mount} from 'enzyme'
 
 describe('EnhancedComponent', () => {
   const Button = ({label}) => <button>{label}</button>
+
+  test('should be able to render non-instantiated React components', () => {
+    const data = {
+      model: new Backbone.Model(),
+    }
+    data.model.on = jest.fn()
+    const wrapper = mount(<EnhancedComponent component={Button} data={data} />)
+
+    expect(data.model.on).toHaveBeenCalled()
+    expect(wrapper.find('button').length).toBe(1)
+  })
 
   test('should listen for changes on models when the component mounts', () => {
     const component = <Button label="Click Me" />
@@ -53,5 +66,197 @@ describe('EnhancedComponent', () => {
     const c = mount(<EnhancedComponent component={component} data={data} />)
     const child = c.find(Button)
     expect(child.props().label).toEqual('Click Me')
+  })
+
+  test('should create a store on init', () => {
+    const component = <Button />
+    const data = {
+      model: new Backbone.Model(),
+    }
+    const c = mount(<EnhancedComponent component={component} data={data} />)
+
+    expect(c.instance().store instanceof BrigadeStore).toBe(true)
+  })
+
+  test('should create a store on init', () => {
+    const component = <Button />
+    const data = {
+      model: new Backbone.Model({label: 'Click Me'}),
+    }
+    const c = mount(<EnhancedComponent component={component} data={data} />)
+
+    expect(c.instance().store instanceof BrigadeStore).toBe(true)
+  })
+
+  test('should not pass props Brigade connected component', () => {
+    const ConnectedComponent = connect(null)(Button)
+    const data = {
+      model: new Backbone.Model({label: 'Click Me'}),
+    }
+    const wrapper = mount(
+      <EnhancedComponent component={ConnectedComponent} data={data} />,
+    )
+
+    const c = wrapper.find('button')
+
+    expect(c.text()).not.toContain('Click Me')
+  })
+
+  test('should connect props to Brigade connected component', () => {
+    const mapStateToProps = state => {
+      return {
+        label: state.model.label,
+      }
+    }
+    const ConnectedComponent = connect(mapStateToProps)(Button)
+
+    const data = {
+      model: new Backbone.Model({label: 'Click Me'}),
+    }
+
+    const wrapper = mount(
+      <EnhancedComponent component={ConnectedComponent} data={data} />,
+    )
+
+    const c = wrapper.find('button')
+
+    expect(c.text()).toContain('Click Me')
+  })
+
+  test('should render instantiated ConnectedComponent', () => {
+    const mapStateToProps = state => {
+      return {
+        label: state.model.label,
+      }
+    }
+    const ConnectedComponent = connect(mapStateToProps)(Button)
+
+    const data = {
+      model: new Backbone.Model({label: 'Click Me'}),
+    }
+
+    const wrapper = mount(
+      <EnhancedComponent component={<ConnectedComponent />} data={data} />,
+    )
+
+    const c = wrapper.find('button')
+
+    expect(c.text()).toContain('Click Me')
+  })
+
+  test('should connect deeply nested component', () => {
+    const mapStateToProps = state => {
+      return {
+        label: state.model.label,
+      }
+    }
+    const ConnectedButton = connect(mapStateToProps)(Button)
+    const App = () => {
+      return (
+        <div>
+          <section>
+            <ConnectedButton />
+          </section>
+        </div>
+      )
+    }
+
+    const data = {
+      model: new Backbone.Model({label: 'Click Me'}),
+    }
+
+    const wrapper = mount(<EnhancedComponent component={App} data={data} />)
+    const c = wrapper.find('button')
+
+    expect(c.text()).toContain('Click Me')
+  })
+
+  test('should not re-render on change if specified + using store for state', () => {
+    const mapStateToProps = state => {
+      return {
+        label: state.model.label,
+      }
+    }
+    const ConnectedButton = connect(mapStateToProps)(Button)
+    const App = () => {
+      return (
+        <div>
+          <section>
+            <ConnectedButton />
+          </section>
+        </div>
+      )
+    }
+
+    const model = new Backbone.Model({label: 'Click Me'})
+
+    const data = {
+      model,
+    }
+
+    const spy = jest.fn()
+    const wrapper = mount(
+      <EnhancedComponent component={App} data={data} useStore />,
+    )
+    wrapper.instance().render = spy
+
+    model.set('label', 'Super Click Me')
+
+    expect(spy).not.toHaveBeenCalled()
+
+    model.set('label', 'One')
+    model.set('label', 'Two')
+    model.set('label', 'Three')
+
+    expect(spy).not.toHaveBeenCalled()
+
+    const c = wrapper.find('button')
+
+    expect(c.text()).toBe('Three')
+  })
+
+  test('should not re-render on change if rendering connected component', () => {
+    const mapStateToProps = state => {
+      return {
+        label: state.model.label,
+      }
+    }
+    const ConnectedButton = connect(mapStateToProps)(Button)
+    const App = () => {
+      return (
+        <div>
+          <section>
+            <ConnectedButton />
+          </section>
+        </div>
+      )
+    }
+    const ConnectedApp = connect()(App)
+
+    const model = new Backbone.Model({label: 'Click Me'})
+
+    const data = {
+      model,
+    }
+
+    const spy = jest.fn()
+    const wrapper = mount(
+      <EnhancedComponent component={ConnectedApp} data={data} />,
+    )
+    wrapper.instance().render = spy
+
+    model.set('label', 'Super Click Me')
+
+    expect(spy).not.toHaveBeenCalled()
+
+    model.set('label', 'One')
+    model.set('label', 'Two')
+    model.set('label', 'Three')
+
+    expect(spy).not.toHaveBeenCalled()
+
+    const c = wrapper.find('button')
+
+    expect(c.text()).toBe('Three')
   })
 })

--- a/src/components/Provider/Provider.js
+++ b/src/components/Provider/Provider.js
@@ -1,0 +1,3 @@
+import {Provider} from 'unistore/react'
+
+export default Provider

--- a/src/components/Provider/index.js
+++ b/src/components/Provider/index.js
@@ -1,0 +1,3 @@
+import Provider from './Provider'
+
+export default Provider

--- a/src/components/connect/__tests__/connect.test.js
+++ b/src/components/connect/__tests__/connect.test.js
@@ -94,4 +94,74 @@ describe('connect', () => {
     metronome.simulate('click')
     expect(store.getState().bpm).toBe(800)
   })
+
+  test('should update store collection via actions', () => {
+    const members = new Backbone.Collection([
+      {
+        firstName: 'Skwisgaar',
+        lastName: 'Skwigelf',
+        id: 'skiwsgaar',
+      },
+    ])
+
+    const store = createStore({
+      members,
+    })
+
+    const Dethklok = ({members, addMember}) => (
+      <div className="dethklok">
+        <div className="members">
+          {members.map(member => (
+            <div key={member.id} className="member">
+              {member.firstName}
+            </div>
+          ))}
+        </div>
+        <button onClick={addMember}>Add Member</button>
+      </div>
+    )
+
+    const mapStateToProps = state => {
+      const {members} = state
+      return {
+        members,
+      }
+    }
+
+    const addMember = () => {
+      // Let's do it with the Backbone collection rather than React store
+      // Cause. Why not!
+      members.add({
+        firstName: 'Toki',
+        lastName: 'Wartooth',
+        id: 'toki',
+      })
+    }
+
+    const ConnectedDethklok = connect(
+      mapStateToProps,
+      {addMember},
+    )(Dethklok)
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <div className="SomeBrutalVenue">
+          <ConnectedDethklok />
+        </div>
+      </Provider>,
+    )
+
+    const el = wrapper.find('div.members')
+    expect(el.text()).toContain('Skwisgaar')
+    expect(wrapper.find('div.member').length).toBe(1)
+
+    const add = wrapper.find('button')
+
+    add.simulate('click')
+
+    expect(el.text()).toContain('Skwisgaar')
+    expect(el.text()).toContain('Toki')
+
+    expect(wrapper.find('div.member').length).toBe(2)
+  })
 })

--- a/src/components/connect/__tests__/connect.test.js
+++ b/src/components/connect/__tests__/connect.test.js
@@ -1,0 +1,97 @@
+import React from 'react'
+import Backbone from 'backbone'
+import {mount} from 'enzyme'
+import Provider from '../../Provider'
+import createStore from '../../createStore'
+import connect from '../index'
+
+describe('connect', () => {
+  test('should connect component to store', () => {
+    const store = createStore({
+      member: new Backbone.Model({
+        firstName: 'Skwisgaar',
+        lastName: 'Skwigelf',
+      }),
+    })
+
+    const Dethklok = ({fullName}) => <div className="dethklok">{fullName}</div>
+
+    const mapStateToProps = state => {
+      const {member} = state
+      return {
+        fullName: `${member.firstName} ${member.lastName}!`,
+      }
+    }
+
+    const ConnectedDethklok = connect(mapStateToProps)(Dethklok)
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <div className="SomeBrutalVenue">
+          <ConnectedDethklok />
+        </div>
+      </Provider>,
+    )
+
+    const el = wrapper.find('div.dethklok')
+
+    expect(el.text()).toBe('Skwisgaar Skwigelf!')
+  })
+
+  test('should update store via actions', () => {
+    const store = createStore({
+      member: new Backbone.Model({
+        firstName: 'Skwisgaar',
+        lastName: 'Skwigelf',
+      }),
+      bpm: 200,
+    })
+
+    const Dethklok = ({fullName, playFaster}) => (
+      <div className="dethklok">
+        {fullName}
+        <button onClick={playFaster}>Shred</button>
+      </div>
+    )
+
+    const mapStateToProps = state => {
+      const {member} = state
+      return {
+        fullName: `${member.firstName} ${member.lastName}!`,
+      }
+    }
+
+    const playFaster = state => {
+      return {
+        ...state,
+        bpm: state.bpm * 2,
+      }
+    }
+
+    const ConnectedDethklok = connect(
+      mapStateToProps,
+      {playFaster},
+    )(Dethklok)
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <div className="SomeBrutalVenue">
+          <ConnectedDethklok />
+        </div>
+      </Provider>,
+    )
+
+    const el = wrapper.find('div.dethklok')
+    expect(el.text()).toContain('Skwisgaar Skwigelf!')
+
+    const metronome = wrapper.find('button')
+
+    expect(store.getState().bpm).toBe(200)
+
+    metronome.simulate('click')
+    expect(store.getState().bpm).toBe(400)
+
+    metronome.simulate('click')
+    expect(store.getState().bpm).toBe(800)
+  })
+})

--- a/src/components/connect/__tests__/utils.test.js
+++ b/src/components/connect/__tests__/utils.test.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import connect from '../connect'
+import {isConnectedComponent} from '../utils'
+
+describe('isConnectedComponent', () => {
+  test('should return false for invalid args', () => {
+    expect(isConnectedComponent()).toBe(false)
+    expect(isConnectedComponent('div')).toBe(false)
+    expect(isConnectedComponent(<div />)).toBe(false)
+  })
+
+  test('should return true for valid connected component', () => {
+    const Murderface = () => <div />
+    const ConnectedMurderFace = connect()(Murderface)
+
+    expect(isConnectedComponent(ConnectedMurderFace)).toBe(true)
+    expect(isConnectedComponent(<ConnectedMurderFace />)).toBe(true)
+  })
+})

--- a/src/components/connect/connect.js
+++ b/src/components/connect/connect.js
@@ -1,3 +1,11 @@
-import {connect} from 'unistore/react'
+import {BRIGADE_CONNECT_KEY} from './utils'
+import {connect as unistoreConnect} from 'unistore/react'
+
+const connect = (mapStateToProps, actions) => Child => {
+  const connectedComponent = unistoreConnect(mapStateToProps, actions)(Child)
+  connectedComponent[BRIGADE_CONNECT_KEY] = true
+
+  return connectedComponent
+}
 
 export default connect

--- a/src/components/connect/connect.js
+++ b/src/components/connect/connect.js
@@ -1,0 +1,3 @@
+import {connect} from 'unistore/react'
+
+export default connect

--- a/src/components/connect/index.js
+++ b/src/components/connect/index.js
@@ -1,0 +1,3 @@
+import connect from './connect'
+
+export default connect

--- a/src/components/connect/utils.js
+++ b/src/components/connect/utils.js
@@ -1,0 +1,12 @@
+import React from 'react'
+export const BRIGADE_CONNECT_KEY = '__SECRET_BRIGADE_CONNECTED_COMPONENT__'
+
+export const isConnectedComponent = Component => {
+  if (!Component) return false
+
+  if (React.isValidElement(Component)) {
+    return Component.type && Component.type[BRIGADE_CONNECT_KEY] === true
+  }
+
+  return Component[BRIGADE_CONNECT_KEY] === true
+}

--- a/src/components/createStore/__tests__/createStore.test.js
+++ b/src/components/createStore/__tests__/createStore.test.js
@@ -1,0 +1,159 @@
+import Backbone from 'backbone'
+import createStore from '../createStore'
+import {BRIGADE_MODEL_KEY} from '../utils'
+
+describe('createStore', () => {
+  test('should accept a Backbone model as initialState', () => {
+    const store = createStore({
+      member: new Backbone.Model({
+        firstName: 'Skwisgaar',
+        lastName: 'Skwigelf',
+      }),
+    })
+
+    expect(store.getState().member.firstName).toBe('Skwisgaar')
+    expect(store.getState().member.lastName).toBe('Skwigelf')
+  })
+
+  test('should accept multiple Backbone models as initialState', () => {
+    const store = createStore({
+      member: new Backbone.Model({
+        firstName: 'Skwisgaar',
+        lastName: 'Skwigelf',
+      }),
+      guitar: new Backbone.Model({
+        brand: 'Gibson',
+        make: 'Explorer',
+        pickups: 'EMG',
+      }),
+    })
+
+    expect(store.getState().member.firstName).toBe('Skwisgaar')
+    expect(store.getState().member.lastName).toBe('Skwigelf')
+    expect(store.getState().guitar.pickups).toBe('EMG')
+  })
+
+  test('should be able to setState on a Backbone model', () => {
+    const store = createStore({
+      member: new Backbone.Model({
+        firstName: 'Skwisgaar',
+        lastName: 'Skwigelf',
+      }),
+    })
+
+    store.setState({
+      member: {
+        ...store.getState().member,
+        firstName: 'Toki',
+      },
+    })
+
+    expect(store.getState().member.firstName).toBe('Toki')
+    expect(store.getState().member.lastName).toBe('Skwigelf')
+  })
+
+  test('should be able to subscribe to store changes', () => {
+    const spy = jest.fn()
+    const store = createStore({
+      member: new Backbone.Model({
+        firstName: 'Skwisgaar',
+        lastName: 'Skwigelf',
+      }),
+    })
+
+    store.subscribe(spy)
+
+    store.setState({
+      member: {
+        ...store.getState().member,
+        firstName: 'Toki',
+      },
+    })
+
+    expect(spy).toHaveBeenCalledWith(
+      {
+        member: {
+          firstName: 'Toki',
+          lastName: 'Skwigelf',
+        },
+      },
+      undefined,
+    )
+  })
+
+  test('should update store on Backbone model changes', () => {
+    const spy = jest.fn()
+    const member = new Backbone.Model({
+      firstName: 'Skwisgaar',
+      lastName: 'Skwigelf',
+    })
+
+    const store = createStore({
+      member,
+      bandName: 'Dethklok',
+    })
+
+    store.subscribe(spy)
+
+    expect(spy).not.toHaveBeenCalled()
+
+    member.set('firstName', 'Toki')
+
+    expect(store.getState().member.firstName).toBe('Toki')
+    expect(store.getState().member.lastName).toBe('Skwigelf')
+    expect(store.getState().bandName).toBe('Dethklok')
+
+    expect(spy).toHaveBeenCalledWith(
+      {
+        member: {
+          firstName: 'Toki',
+          lastName: 'Skwigelf',
+        },
+        bandName: 'Dethklok',
+      },
+      undefined,
+    )
+  })
+
+  test('should unsubscribe on destroy', () => {
+    const spy = jest.fn()
+    const member = new Backbone.Model({
+      firstName: 'Skwisgaar',
+      lastName: 'Skwigelf',
+    })
+
+    const store = createStore({
+      member,
+    })
+
+    store.subscribe(spy)
+
+    store.destroy()
+
+    member.set('firstName', 'Toki')
+
+    expect(store.getState().member.firstName).toBe('Skwisgaar')
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  test('should not update store if, some how, the Brigade secret key is removed', () => {
+    const spy = jest.fn()
+    const member = new Backbone.Model({
+      firstName: 'Skwisgaar',
+      lastName: 'Skwigelf',
+    })
+
+    const store = createStore({
+      member,
+    })
+
+    store.subscribe(spy)
+
+    member[BRIGADE_MODEL_KEY] = undefined
+
+    member.set('firstName', 'Toki')
+
+    expect(store.getState().member.firstName).toBe('Skwisgaar')
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/createStore/__tests__/createStore.test.js
+++ b/src/components/createStore/__tests__/createStore.test.js
@@ -3,157 +3,368 @@ import createStore from '../createStore'
 import {BRIGADE_MODEL_KEY} from '../utils'
 
 describe('createStore', () => {
-  test('should accept a Backbone model as initialState', () => {
-    const store = createStore({
-      member: new Backbone.Model({
-        firstName: 'Skwisgaar',
-        lastName: 'Skwigelf',
-      }),
-    })
-
-    expect(store.getState().member.firstName).toBe('Skwisgaar')
-    expect(store.getState().member.lastName).toBe('Skwigelf')
-  })
-
-  test('should accept multiple Backbone models as initialState', () => {
-    const store = createStore({
-      member: new Backbone.Model({
-        firstName: 'Skwisgaar',
-        lastName: 'Skwigelf',
-      }),
-      guitar: new Backbone.Model({
-        brand: 'Gibson',
-        make: 'Explorer',
-        pickups: 'EMG',
-      }),
-    })
-
-    expect(store.getState().member.firstName).toBe('Skwisgaar')
-    expect(store.getState().member.lastName).toBe('Skwigelf')
-    expect(store.getState().guitar.pickups).toBe('EMG')
-  })
-
-  test('should be able to setState on a Backbone model', () => {
-    const store = createStore({
-      member: new Backbone.Model({
-        firstName: 'Skwisgaar',
-        lastName: 'Skwigelf',
-      }),
-    })
-
-    store.setState({
-      member: {
-        ...store.getState().member,
-        firstName: 'Toki',
-      },
-    })
-
-    expect(store.getState().member.firstName).toBe('Toki')
-    expect(store.getState().member.lastName).toBe('Skwigelf')
-  })
-
-  test('should be able to subscribe to store changes', () => {
-    const spy = jest.fn()
-    const store = createStore({
-      member: new Backbone.Model({
-        firstName: 'Skwisgaar',
-        lastName: 'Skwigelf',
-      }),
-    })
-
-    store.subscribe(spy)
-
-    store.setState({
-      member: {
-        ...store.getState().member,
-        firstName: 'Toki',
-      },
-    })
-
-    expect(spy).toHaveBeenCalledWith(
-      {
-        member: {
-          firstName: 'Toki',
+  describe('Backbone.Model', () => {
+    test('should accept a Backbone model in initialState', () => {
+      const store = createStore({
+        member: new Backbone.Model({
+          firstName: 'Skwisgaar',
           lastName: 'Skwigelf',
-        },
-      },
-      undefined,
-    )
-  })
+        }),
+      })
 
-  test('should update store on Backbone model changes', () => {
-    const spy = jest.fn()
-    const member = new Backbone.Model({
-      firstName: 'Skwisgaar',
-      lastName: 'Skwigelf',
+      expect(store.getState().member.firstName).toBe('Skwisgaar')
+      expect(store.getState().member.lastName).toBe('Skwigelf')
     })
 
-    const store = createStore({
-      member,
-      bandName: 'Dethklok',
-    })
-
-    store.subscribe(spy)
-
-    expect(spy).not.toHaveBeenCalled()
-
-    member.set('firstName', 'Toki')
-
-    expect(store.getState().member.firstName).toBe('Toki')
-    expect(store.getState().member.lastName).toBe('Skwigelf')
-    expect(store.getState().bandName).toBe('Dethklok')
-
-    expect(spy).toHaveBeenCalledWith(
-      {
-        member: {
-          firstName: 'Toki',
+    test('should accept multiple Backbone models in initialState', () => {
+      const store = createStore({
+        member: new Backbone.Model({
+          firstName: 'Skwisgaar',
           lastName: 'Skwigelf',
+        }),
+        guitar: new Backbone.Model({
+          brand: 'Gibson',
+          make: 'Explorer',
+          pickups: 'EMG',
+        }),
+      })
+
+      expect(store.getState().member.firstName).toBe('Skwisgaar')
+      expect(store.getState().member.lastName).toBe('Skwigelf')
+      expect(store.getState().guitar.pickups).toBe('EMG')
+    })
+
+    test('should be able to setState on a Backbone model', () => {
+      const store = createStore({
+        member: new Backbone.Model({
+          firstName: 'Skwisgaar',
+          lastName: 'Skwigelf',
+        }),
+      })
+
+      store.setState({
+        member: {
+          ...store.getState().member,
+          firstName: 'Toki',
         },
+      })
+
+      expect(store.getState().member.firstName).toBe('Toki')
+      expect(store.getState().member.lastName).toBe('Skwigelf')
+    })
+
+    test('should be able to subscribe to store changes', () => {
+      const spy = jest.fn()
+      const store = createStore({
+        member: new Backbone.Model({
+          firstName: 'Skwisgaar',
+          lastName: 'Skwigelf',
+        }),
+      })
+
+      store.subscribe(spy)
+
+      store.setState({
+        member: {
+          ...store.getState().member,
+          firstName: 'Toki',
+        },
+      })
+
+      expect(spy).toHaveBeenCalledWith(
+        {
+          member: {
+            firstName: 'Toki',
+            lastName: 'Skwigelf',
+          },
+        },
+        undefined,
+      )
+    })
+
+    test('should update store on Backbone model changes', () => {
+      const spy = jest.fn()
+      const member = new Backbone.Model({
+        firstName: 'Skwisgaar',
+        lastName: 'Skwigelf',
+      })
+
+      const store = createStore({
+        member,
         bandName: 'Dethklok',
+      })
+
+      store.subscribe(spy)
+
+      expect(spy).not.toHaveBeenCalled()
+
+      member.set('firstName', 'Toki')
+
+      expect(store.getState().member.firstName).toBe('Toki')
+      expect(store.getState().member.lastName).toBe('Skwigelf')
+      expect(store.getState().bandName).toBe('Dethklok')
+
+      expect(spy).toHaveBeenCalledWith(
+        {
+          member: {
+            firstName: 'Toki',
+            lastName: 'Skwigelf',
+          },
+          bandName: 'Dethklok',
+        },
+        undefined,
+      )
+    })
+
+    test('should unsubscribe on destroy', () => {
+      const spy = jest.fn()
+      const member = new Backbone.Model({
+        firstName: 'Skwisgaar',
+        lastName: 'Skwigelf',
+      })
+
+      const store = createStore({
+        member,
+      })
+
+      store.subscribe(spy)
+
+      store.destroy()
+
+      member.set('firstName', 'Toki')
+
+      expect(store.getState().member.firstName).toBe('Skwisgaar')
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    test('should not update store if, some how, the Brigade secret key is removed', () => {
+      const spy = jest.fn()
+      const member = new Backbone.Model({
+        firstName: 'Skwisgaar',
+        lastName: 'Skwigelf',
+      })
+
+      const store = createStore({
+        member,
+      })
+
+      store.subscribe(spy)
+
+      member[BRIGADE_MODEL_KEY] = undefined
+
+      member.set('firstName', 'Toki')
+
+      expect(store.getState().member.firstName).toBe('Skwisgaar')
+      expect(spy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Backbone.Collection', () => {
+    const initialMembers = [
+      {
+        firstName: 'Skwisgaar',
+        lastName: 'Skwigelf',
+        id: 'skwisgaar',
       },
-      undefined,
-    )
-  })
+      {
+        firstName: 'Toki',
+        lastName: 'Wartooth',
+        id: 'toki',
+      },
+    ]
 
-  test('should unsubscribe on destroy', () => {
-    const spy = jest.fn()
-    const member = new Backbone.Model({
-      firstName: 'Skwisgaar',
-      lastName: 'Skwigelf',
+    test('should accept a Backbone collection in initialState', () => {
+      const Members = Backbone.Collection.extend({
+        model: Backbone.Model,
+      })
+
+      const members = new Members(initialMembers)
+
+      const store = createStore({
+        members,
+      })
+
+      expect(Array.isArray(store.getState().members)).toBe(true)
+      expect(store.getState().members.length).toBe(2)
+      expect(store.getState().members[0]).toEqual({
+        firstName: 'Skwisgaar',
+        lastName: 'Skwigelf',
+        id: 'skwisgaar',
+      })
+      expect(store.getState().members[1]).toEqual({
+        firstName: 'Toki',
+        lastName: 'Wartooth',
+        id: 'toki',
+      })
     })
 
-    const store = createStore({
-      member,
+    test('should be able to add to collection', () => {
+      const Members = Backbone.Collection.extend({
+        model: Backbone.Model,
+      })
+      const members = new Members(initialMembers)
+
+      const store = createStore({
+        members,
+      })
+
+      members.add({
+        firstName: 'William',
+        lastName: 'Murderface',
+        id: 'murderface',
+      })
+
+      expect(store.getState().members.length).toBe(3)
+      expect(store.getState().members[2].lastName).toBe('Murderface')
     })
 
-    store.subscribe(spy)
+    test('should be able to add/remove from to collection', () => {
+      const Members = Backbone.Collection.extend({
+        model: Backbone.Model,
+      })
+      const members = new Members(initialMembers)
 
-    store.destroy()
+      const store = createStore({
+        members,
+      })
 
-    member.set('firstName', 'Toki')
+      members.add({
+        firstName: 'William',
+        lastName: 'Murderface',
+        id: 'murderface',
+      })
 
-    expect(store.getState().member.firstName).toBe('Skwisgaar')
-    expect(spy).not.toHaveBeenCalled()
-  })
+      members.remove('skwisgaar')
 
-  test('should not update store if, some how, the Brigade secret key is removed', () => {
-    const spy = jest.fn()
-    const member = new Backbone.Model({
-      firstName: 'Skwisgaar',
-      lastName: 'Skwigelf',
+      expect(store.getState().members[0].lastName).toBe('Wartooth')
+      expect(store.getState().members[1].lastName).toBe('Murderface')
+
+      members.add({
+        firstName: 'Nathan',
+        lastName: 'Explosion',
+        id: 'nathan',
+      })
+
+      expect(store.getState().members.length).toBe(3)
     })
 
-    const store = createStore({
-      member,
+    test('should be able to change within to collection', () => {
+      const Members = Backbone.Collection.extend({
+        model: Backbone.Model,
+      })
+      const members = new Members(initialMembers)
+
+      const store = createStore({
+        members,
+      })
+
+      members.add({
+        firstName: 'William',
+        lastName: 'Murderface',
+        id: 'murderface',
+      })
+
+      members.findWhere({id: 'murderface'}).set({
+        lastName: 'MurderfaceMurderfaceMurderface',
+      })
+
+      expect(store.getState().members.length).toBe(3)
+      expect(store.getState().members[2].lastName).toBe(
+        'MurderfaceMurderfaceMurderface',
+      )
     })
 
-    store.subscribe(spy)
+    test('should be able to reset to collection', () => {
+      const Members = Backbone.Collection.extend({
+        model: Backbone.Model,
+      })
+      const members = new Members(initialMembers)
 
-    member[BRIGADE_MODEL_KEY] = undefined
+      const store = createStore({
+        members,
+      })
 
-    member.set('firstName', 'Toki')
+      expect(store.getState().members.length).toBe(2)
 
-    expect(store.getState().member.firstName).toBe('Skwisgaar')
-    expect(spy).not.toHaveBeenCalled()
+      members.reset()
+
+      expect(store.getState().members.length).toBe(0)
+    })
+
+    test('should be able to subscribe to store changes', () => {
+      const spy = jest.fn()
+      const Members = Backbone.Collection.extend({
+        model: Backbone.Model,
+      })
+      const members = new Members(initialMembers)
+
+      const store = createStore({
+        members,
+      })
+
+      store.subscribe(spy)
+
+      expect(spy).not.toHaveBeenCalled()
+
+      members.add({
+        firstName: 'William',
+        lastName: 'Murderface',
+        id: 'murderface',
+      })
+
+      expect(spy).toHaveBeenCalled()
+    })
+
+    test('should be able to unsubscribe to store changes', () => {
+      const spy = jest.fn()
+      const Members = Backbone.Collection.extend({
+        model: Backbone.Model,
+      })
+      const members = new Members(initialMembers)
+
+      const store = createStore({
+        members,
+      })
+
+      store.subscribe(spy)
+
+      expect(spy).not.toHaveBeenCalled()
+
+      store.unsubscribe(spy)
+
+      members.add({
+        firstName: 'William',
+        lastName: 'Murderface',
+        id: 'murderface',
+      })
+
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    test('should unsubscribe on destroy', () => {
+      const spy = jest.fn()
+      const Members = Backbone.Collection.extend({
+        model: Backbone.Model,
+      })
+      const members = new Members(initialMembers)
+
+      const store = createStore({
+        members,
+      })
+
+      store.subscribe(spy)
+
+      expect(spy).not.toHaveBeenCalled()
+
+      store.destroy()
+
+      members.add({
+        firstName: 'William',
+        lastName: 'Murderface',
+        id: 'murderface',
+      })
+
+      expect(spy).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/components/createStore/__tests__/utils.test.js
+++ b/src/components/createStore/__tests__/utils.test.js
@@ -1,0 +1,40 @@
+import Backbone from 'backbone'
+import {
+  BRIGADE_MODEL_KEY,
+  enhanceBackboneModelWithBrigade,
+  getModelsFromProps,
+} from '../utils'
+
+describe('getModelsFromProps', () => {
+  test('should return empty array by default', () => {
+    expect(getModelsFromProps()).toEqual([])
+  })
+
+  test('should retrieve Backbone models', () => {
+    const props = {
+      vocalist: new Backbone.Model({name: 'Nathan Explosion'}),
+    }
+    const models = getModelsFromProps(props)
+
+    expect(models).not.toEqual([])
+    expect(models[0][BRIGADE_MODEL_KEY]).toBe('vocalist')
+  })
+})
+
+describe('enhanceBackboneModelWithBrigade', () => {
+  test('should enhance object, if a Backbone model', () => {
+    const obj = new Backbone.Model({name: 'Nathan Explosion'})
+
+    enhanceBackboneModelWithBrigade(obj, 'brutal')
+
+    expect(obj[BRIGADE_MODEL_KEY]).toBe('brutal')
+  })
+
+  test('should not enhance object, if not a Backbone model', () => {
+    const obj = {name: 'Nathan Explosion'}
+
+    enhanceBackboneModelWithBrigade(obj, 'brutal')
+
+    expect(obj[BRIGADE_MODEL_KEY]).toBeUndefined()
+  })
+})

--- a/src/components/createStore/__tests__/utils.test.js
+++ b/src/components/createStore/__tests__/utils.test.js
@@ -1,8 +1,9 @@
 import Backbone from 'backbone'
 import {
   BRIGADE_MODEL_KEY,
-  enhanceBackboneModelWithBrigade,
+  enhanceBackboneClassWithBrigade,
   getModelsFromProps,
+  getCollectionsFromProps,
 } from '../utils'
 
 describe('getModelsFromProps', () => {
@@ -21,19 +22,43 @@ describe('getModelsFromProps', () => {
   })
 })
 
-describe('enhanceBackboneModelWithBrigade', () => {
+describe('getCollectionsFromProps', () => {
+  test('should return empty array by default', () => {
+    expect(getCollectionsFromProps()).toEqual([])
+  })
+
+  test('should retrieve Backbone collections', () => {
+    const props = {
+      members: new Backbone.Collection({name: 'Nathan Explosion'}),
+    }
+    const collections = getCollectionsFromProps(props)
+
+    expect(collections).not.toEqual([])
+    expect(collections[0][BRIGADE_MODEL_KEY]).toBe('members')
+  })
+})
+
+describe('enhanceBackboneClassWithBrigade', () => {
   test('should enhance object, if a Backbone model', () => {
     const obj = new Backbone.Model({name: 'Nathan Explosion'})
 
-    enhanceBackboneModelWithBrigade(obj, 'brutal')
+    enhanceBackboneClassWithBrigade(obj, 'brutal')
 
     expect(obj[BRIGADE_MODEL_KEY]).toBe('brutal')
   })
 
-  test('should not enhance object, if not a Backbone model', () => {
+  test('should enhance object, if a Backbone collection', () => {
+    const obj = new Backbone.Collection()
+
+    enhanceBackboneClassWithBrigade(obj, 'brutal')
+
+    expect(obj[BRIGADE_MODEL_KEY]).toBe('brutal')
+  })
+
+  test('should not enhance object, if not a Backbone model/collection', () => {
     const obj = {name: 'Nathan Explosion'}
 
-    enhanceBackboneModelWithBrigade(obj, 'brutal')
+    enhanceBackboneClassWithBrigade(obj, 'brutal')
 
     expect(obj[BRIGADE_MODEL_KEY]).toBeUndefined()
   })

--- a/src/components/createStore/createStore.js
+++ b/src/components/createStore/createStore.js
@@ -1,0 +1,54 @@
+import unistoreCreateStore from 'unistore'
+import transformDataToProps from '../EnhancedComponent/util/transformDataToProps'
+import {BRIGADE_MODEL_KEY, getModelsFromProps} from './utils'
+
+export class BrigadeStore {
+  constructor(initialState) {
+    // Secret store within the store
+    this.__store = unistoreCreateStore(transformDataToProps(initialState))
+    this.initialState = initialState
+    this.models = getModelsFromProps(initialState)
+
+    this.watch()
+  }
+
+  destroy = () => {
+    this.unwatch()
+    this.unsubscribe()
+  }
+
+  updatePropsFromModelChange(nextModel) {
+    const key = nextModel[BRIGADE_MODEL_KEY]
+    if (!key) return
+
+    const props = nextModel.toJSON()
+
+    this.__store.setState({
+      member: props,
+    })
+  }
+
+  unwatch() {
+    this.models.forEach(model => {
+      model.off('change', this.updatePropsFromModelChange, this)
+    })
+  }
+
+  watch() {
+    this.models.forEach(model => {
+      model.on('change', this.updatePropsFromModelChange, this)
+    })
+  }
+
+  getState = () => this.__store.getState()
+  setState = newState => this.__store.setState(newState)
+  action = action => this.__store.action(action)
+  subscribe = callback => this.__store.subscribe(callback)
+  unsubscribe = listener => this.__store.unsubscribe(listener)
+}
+
+const createStore = state => {
+  return new BrigadeStore(state)
+}
+
+export default createStore

--- a/src/components/createStore/createStore.js
+++ b/src/components/createStore/createStore.js
@@ -24,7 +24,7 @@ export class BrigadeStore {
     const props = nextModel.toJSON()
 
     this.__store.setState({
-      member: props,
+      [key]: props,
     })
   }
 

--- a/src/components/createStore/index.js
+++ b/src/components/createStore/index.js
@@ -1,0 +1,3 @@
+import createStore from './createStore'
+
+export default createStore

--- a/src/components/createStore/utils.js
+++ b/src/components/createStore/utils.js
@@ -1,0 +1,23 @@
+export const BRIGADE_MODEL_KEY = '__SECRET_BRIGADE_MODEL_KEY__'
+
+export const getModelsFromProps = (data = {}) => {
+  return Object.keys(data).reduce((accumulator, key) => {
+    const value = data[key]
+    if (isBackboneModel(value)) {
+      enhanceBackboneModelWithBrigade(value, key)
+      accumulator.push(value)
+    }
+
+    return accumulator
+  }, [])
+}
+
+export const enhanceBackboneModelWithBrigade = (model, key) => {
+  if (!isBackboneModel(model)) return model
+  model[BRIGADE_MODEL_KEY] = key
+
+  return model
+}
+
+export const isBackboneModel = obj =>
+  obj && typeof obj === 'object' && typeof obj.toJSON === 'function'

--- a/src/components/createStore/utils.js
+++ b/src/components/createStore/utils.js
@@ -1,10 +1,14 @@
+import Backbone from 'backbone'
+
 export const BRIGADE_MODEL_KEY = '__SECRET_BRIGADE_MODEL_KEY__'
+export const COLLECTION_EVENTS = 'add change remove reset'
+export const MODEL_EVENTS = 'change'
 
 export const getModelsFromProps = (data = {}) => {
   return Object.keys(data).reduce((accumulator, key) => {
     const value = data[key]
-    if (isBackboneModel(value)) {
-      enhanceBackboneModelWithBrigade(value, key)
+    if (isModel(value)) {
+      enhanceBackboneClassWithBrigade(value, key)
       accumulator.push(value)
     }
 
@@ -12,12 +16,25 @@ export const getModelsFromProps = (data = {}) => {
   }, [])
 }
 
-export const enhanceBackboneModelWithBrigade = (model, key) => {
-  if (!isBackboneModel(model)) return model
-  model[BRIGADE_MODEL_KEY] = key
+export const getCollectionsFromProps = (data = {}) => {
+  return Object.keys(data).reduce((accumulator, key) => {
+    const value = data[key]
+    if (isCollection(value)) {
+      enhanceBackboneClassWithBrigade(value, key)
+      accumulator.push(value)
+    }
 
-  return model
+    return accumulator
+  }, [])
 }
 
-export const isBackboneModel = obj =>
-  obj && typeof obj === 'object' && typeof obj.toJSON === 'function'
+export const enhanceBackboneClassWithBrigade = (backboneClass, key) => {
+  if (!isBackboneClass(backboneClass)) return backboneClass
+  backboneClass[BRIGADE_MODEL_KEY] = key
+
+  return backboneClass
+}
+
+export const isModel = obj => obj && obj instanceof Backbone.Model
+export const isCollection = obj => obj && obj instanceof Backbone.Collection
+export const isBackboneClass = obj => isModel(obj) || isCollection(obj)

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,1 +1,4 @@
-export { EnhancedComponent } from "./EnhancedComponent";
+export {EnhancedComponent} from './EnhancedComponent'
+export {createStore} from './createStore'
+export {Provider} from './Provider'
+export {connect} from './connect'


### PR DESCRIPTION
## Store + Connect

This update adds a couple of new components/conventions that center around bringing a more opinionated approach to data flow between Backbone -> React via Brigade.

In other words, make it more Redux-y 😂 

Under the hood, it uses [Unistore](https://github.com/developit/unistore), which is a < 1KB Redux created by [Mr. Preact](https://github.com/developit).

Brigade's `createStore` uses `unistore`, but enhances it slightly to subscribe to Backbone model changes (and makes updates as required).

Connecting to the store (`Provider`) works like out-of-the-box Unistore or Redux.

Check out [unistore's documentation](https://github.com/developit/unistore) for more details :)