### PR TITLE
Change actions to mapActionsToProps

### DIFF
--- a/docs/03-ReactMounter.mdx
+++ b/docs/03-ReactMounter.mdx
@@ -217,13 +217,13 @@ import { connect } from '@helpscout/brigade'
 import Form from '../Form'
 
 const mapStateToProps = ({ person, people }) => ({ person, people })
-const actions = store => {
+const mapActionsToProps = store => {
   const { addPerson } = store.getExternalActions()
   return {
     addPerson: (state, person) => addPerson(person)
   }
 }
-connect(mapStateToProps, addPerson)(Form)
+connect(mapStateToProps, mapActionsToProps)(Form)
 ```
 
 The above example illustrates how we can grab state and actions out of the store
@@ -240,11 +240,11 @@ returns the external actions where each action has been remapped to remove
 `state` as the first argument.
 
 ```
-const actions = store => {
+const mapActionsToProps = store => {
   const { addPerson } = store.getStatelessExternalActions()
   return { addPerson }
 }
-connect(null, addPerson)(Form)
+connect(null, mapActionsToProps)(Form)
 ```
 
 You will note in the above example, we do not need to remap the `addPerson`

--- a/stories/ReactMounter/components/List.js
+++ b/stories/ReactMounter/components/List.js
@@ -8,7 +8,7 @@ import {connect} from '../../../src'
 class List extends PureComponent {
   static propTypes = {
     addItem: PropTypes.func,
-    items: PropTypes.array,
+    items: PropTypes.array.isRequired,
     list: PropTypes.shape({
       name: PropTypes.string,
       version: PropTypes.number,
@@ -66,8 +66,8 @@ const mapStateToProps = ({items, list}) => ({
   items,
   list,
 })
-const actions = store => store.getExternalActions()
+const mapActionsToProps = store => store.getExternalActions()
 export const ConnectedList = connect(
   mapStateToProps,
-  actions,
+  mapActionsToProps,
 )(List)

--- a/stories/ReactMounter/components/Todo/TodoForm.js
+++ b/stories/ReactMounter/components/Todo/TodoForm.js
@@ -52,17 +52,12 @@ class TodoForm extends Component {
   }
 }
 
-const actions = store => {
-  const {addTodo} = store.getExternalActions()
-  return {
-    // We are remapping this action because our store re-binds actions to take
-    // state as the first argument, but the `addTodo` method which came from
-    // our Marionette view expects `todo` as the first and only argument.
-    addTodo: (state, todo) => addTodo(todo),
-  }
+const mapActionsToProps = store => {
+  const {addTodo} = store.getStatelessExternalActions()
+  return {addTodo}
 }
 
 export default connect(
   null,
-  actions,
+  mapActionsToProps,
 )(TodoForm)

--- a/stories/ReactMounter/components/Todo/TodoListItem.js
+++ b/stories/ReactMounter/components/Todo/TodoListItem.js
@@ -36,14 +36,12 @@ class TodoListItem extends PureComponent {
   }
 }
 
-const actions = store => {
-  const {removeTodo} = store.getExternalActions()
-  return {
-    removeTodo: (_state, id) => removeTodo(id),
-  }
+const mapActionsToProps = store => {
+  const {removeTodo} = store.getStatelessExternalActions()
+  return {removeTodo}
 }
 
 export default connect(
   null,
-  actions,
+  mapActionsToProps,
 )(TodoListItem)


### PR DESCRIPTION
The `connect` HOF exported by Brigade takes two arguments, one to map state to props conventionally named `mapStateToProps`, the other to map actions to props, unconventionally named `actions`.

This PR updates stories and docs to rename `actions` to `mapActionsToProps`. It does not change any executable code. Rather it is to set a good example for users of the library.