### PR TITLE
Do not use ES6 modules

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,1 +1,4 @@
-{"presets": ["@helpscout/zero/babel"]}
+{
+  "presets": ["@helpscout/zero/babel"],
+  "plugins": ["@babel/plugin-transform-modules-commonjs"]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/brigade",
-  "version": "1.0.2",
+  "version": "1.0.3-rc.0",
   "description": "Backbone-controlled React components",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes an issue where the code was being transpiled with ES6 modules which are not supported by NodeJS runtimes and therefore causing issues using Brigade in Jest tests.