### PR TITLE
Netlify: Add SPA redirects for linkable routes

### DIFF
--- a/netlify.toml 
+++ b/netlify.toml 
@@ -1,0 +1,10 @@
+# Netlify Config
+# Reference:
+# https://www.netlify.com/docs/netlify-toml-reference/
+
+# The following redirect is intended for use with most SPAs that handle
+# routing internally.
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## Netlify: Add SPA redirects for linkable routes

This update adds a new `netlify.toml` file with redirect rules to help SPAs,
like Docz, correctly redirect to the desired route, instead of 404'ing.

For reference:
https://www.netlify.com/docs/redirects/#rewrites-and-proxying

And

https://www.netlify.com/docs/netlify-toml-reference/

❤️ 