### PR TITLE
Add combineAppRoutes util

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "zero format",
     "validate": "zero validate",
     "precommit": "zero pre-commit",
+    "dev": "npm run test:watch",
     "test": "zero test --coverage",
     "test:watch": "zero test --watch",
     "version": "npm run build",

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export {connect} from './components'
 export {ReactMounter, ReactView} from './hoc'
+export {combineAppRoutes} from './router'

--- a/src/router/__tests__/combineAppRoutes.test.js
+++ b/src/router/__tests__/combineAppRoutes.test.js
@@ -1,0 +1,105 @@
+import {combineAppRoutes} from '../combineAppRoutes'
+
+describe('combineAppRoutes', () => {
+  test('Returns an empty object by defaul;t', () => {
+    expect(combineAppRoutes()).toEqual({})
+  })
+
+  test('Returns marionetteRoutes unmodified', () => {
+    const marionetteRoutes = {
+      'app(/)': 'app',
+      'settings(/)': 'settingsApp',
+    }
+
+    const combinedRoutes = combineAppRoutes({marionetteRoutes})
+
+    expect(combinedRoutes).toEqual(marionetteRoutes)
+  })
+
+  test('Can modify single reactRoutes', () => {
+    const reactRoutes = {
+      reactApp: 'someReactApp',
+    }
+
+    const combinedRoutes = combineAppRoutes({reactRoutes})
+
+    expect(combinedRoutes).toEqual({
+      'reactApp/(*notFound)': 'someReactApp',
+    })
+  })
+
+  test('Can modify multiple reactRoutes', () => {
+    const reactRoutes = {
+      reactApp: 'someReactApp',
+      anotherReactApp: 'yetAnotherReactApp',
+      thirdOne: 'whyNot',
+    }
+
+    const combinedRoutes = combineAppRoutes({reactRoutes})
+
+    expect(combinedRoutes).toEqual({
+      'reactApp/(*notFound)': 'someReactApp',
+      'anotherReactApp/(*notFound)': 'yetAnotherReactApp',
+      'thirdOne/(*notFound)': 'whyNot',
+    })
+  })
+
+  test('Can handle nested React routes', () => {
+    const reactRoutes = {
+      'one/two/three': 'someReactApp',
+    }
+
+    const combinedRoutes = combineAppRoutes({reactRoutes})
+
+    expect(combinedRoutes).toEqual({
+      'one/two/three/(*notFound)': 'someReactApp',
+    })
+  })
+
+  test('Can handle React routes ending with (/)', () => {
+    const reactRoutes = {
+      'reactApp(/)': 'someReactApp',
+    }
+
+    const combinedRoutes = combineAppRoutes({reactRoutes})
+
+    expect(combinedRoutes).toEqual({
+      'reactApp/(*notFound)': 'someReactApp',
+    })
+  })
+
+  test('Can handle nested React routes ending with (/)', () => {
+    const reactRoutes = {
+      'one/two/three(/)': 'someReactApp',
+    }
+
+    const combinedRoutes = combineAppRoutes({reactRoutes})
+
+    expect(combinedRoutes).toEqual({
+      'one/two/three/(*notFound)': 'someReactApp',
+    })
+  })
+
+  test('Can combine reactRoutes and marionetteRoutes', () => {
+    const reactRoutes = {
+      reactApp: 'someReactApp',
+      anotherReactApp: 'yetAnotherReactApp',
+      'thirdOne(/)': 'whyNot',
+    }
+
+    const marionetteRoutes = {
+      'app/sub(/)': 'app',
+      'settings(/)': 'settingsApp',
+    }
+
+    const combinedRoutes = combineAppRoutes({reactRoutes, marionetteRoutes})
+
+    expect(combinedRoutes).toEqual({
+      'reactApp/(*notFound)': 'someReactApp',
+      'anotherReactApp/(*notFound)': 'yetAnotherReactApp',
+      'thirdOne/(*notFound)': 'whyNot',
+      'app/sub(/)': 'app',
+      'settings(/)': 'settingsApp',
+    })
+  })
+})

--- a/src/router/__tests__/router.test.js
+++ b/src/router/__tests__/router.test.js
@@ -1,0 +1,5 @@
+import {combineAppRoutes} from '../index'
+
+test('combineAppRoutes should be exported', () => {
+  expect(combineAppRoutes).toBeTruthy()
+})

--- a/src/router/combineAppRoutes.js
+++ b/src/router/combineAppRoutes.js
@@ -1,0 +1,31 @@
+export const defaultRouteOptions = {
+  reactRoutes: {},
+  marionetteRoutes: {},
+}
+
+export const sanitizeRouteKey = route => {
+  const [baseRoute] = route.split('(/)')
+
+  return `${baseRoute}/(*notFound)`
+}
+
+export const combineAppRoutes = (routeOptions = defaultRouteOptions) => {
+  const {reactRoutes, marionetteRoutes} = {
+    ...defaultRouteOptions,
+    ...routeOptions,
+  }
+
+  const enhancedReactRoutes = Object.keys(reactRoutes).reduce((routes, key) => {
+    return {
+      ...routes,
+      [sanitizeRouteKey(key)]: reactRoutes[key],
+    }
+  }, {})
+
+  return {
+    ...marionetteRoutes,
+    ...enhancedReactRoutes,
+  }
+}
+
+export default combineAppRoutes

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,0 +1,1 @@
+export {default as combineAppRoutes} from './combineAppRoutes'


### PR DESCRIPTION
## Add combineAppRoutes util

This update adds a new combineAppRoutes utility function. This enables Marionette
apps to render a React Router powered component/app. It works by combining React
routes and Marionette Routes to a flat object for Marionette's appRouter.

The trick is to have the React routes end with `*notFound`, which kind of functions
like a wild card match.

It's an unfortunate thing, but it's the only thing that seems to work.