### PR TITLE
Remove deprecation notice and update docs

### DIFF
--- a/docs/03-ReactMounter.mdx
+++ b/docs/03-ReactMounter.mdx
@@ -1,11 +1,9 @@
 ---
-name: ReactMounter (Deprecated)
+name: ReactMounter
 route: /react-mounter
 ---
 
 # ReactMounter
-
-###  (Deprecated)
 
 ReactMounter is a higher order function (HOF) that ships with Brigade since
 1.0.0. It replaces the default export from Brigade 0.x.
@@ -196,13 +194,15 @@ app.
 
 ```
 components() {
-  '#app': App,
-  initialState: {
-    person: this.person,
-    people: this.people,
-  },
-  externalActions: {
-    addPerson: this.addPerson,
+  '#app': {
+    component: App,
+    initialState: {
+      person: this.person,
+      people: this.people,
+    },
+    externalActions: {
+      addPerson: this.addPerson,
+    }
   }
 }
 ```
@@ -255,8 +255,12 @@ argument will be the `person`, not the `state`.
 
 ## Ideal Use Case
 
-ReactMounter is ideally suited for mounting complex React components or entire
-React applications inside of a Backbone or Marionette view. In such cases,
-all or some of the business logic and state is managed in Backbone or Marionette
-and synced with the React app via ReactMounter. The entire user interface of
-the feature would be built with React.
+ReactMounter is ideally suited for mounting one or more complex React components
+or entire React applications inside a Backbone or Marionette View, particularly
+where all of the business logic and state is controlled in the Backbone or 
+Marionette app and you are interested in syncing its state with React components
+or apps.
+
+In cases where you want to use Redux to manage state or where you are interested
+in migrating to a Redux architecture, you should use [StatefulReactView](/stateful-react-view)
+instead.


### PR DESCRIPTION
This addresses #19 by removing the deprecation notice on ReactMounter.

ReactMounter continues to be a useful abstraction for cases where React is used in conjunction with Backbone/Marionette without the Redux Architecture. Moreover it is more broadly compatible with Backbone and Marionette then StatefulReactView which requires Marionette 1.8.x. ReactMounter has no such restriction.