### PR TITLE
Update Getting Started Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ project, then Brigade is not for you. In this case, try
 Brigade has the following peer dependencies:
 
 - [Backbone](https://www.npmjs.com/package/backbone)
-- [Marionette](https://www.npmjs.com/package/backbone.marionette) (Optional)
+- [Marionette](https://www.npmjs.com/package/backbone.marionette)
 - [React](https://www.npmjs.com/package/react)
 - [React DOM](https://www.npmjs.com/package/react-dom)
 - [React Redux](https://www.npmjs.com/package/react-redux)
 - [Redux](https://www.npmjs.com/package/redux)
 - [Redux Thunk](https://www.npmjs.com/package/redux-thunk)
 
-Marionette is optional. Backbone requires jQuery and Underscore.
+Backbone requires jQuery and Underscore.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Brigade has the following peer dependencies:
 - [Marionette](https://www.npmjs.com/package/backbone.marionette) (Optional)
 - [React](https://www.npmjs.com/package/react)
 - [React DOM](https://www.npmjs.com/package/react-dom)
+- [React Redux](https://www.npmjs.com/package/react-redux)
+- [Redux](https://www.npmjs.com/package/redux)
+- [Redux Thunk](https://www.npmjs.com/package/redux-thunk)
 
 Marionette is optional. Backbone requires jQuery and Underscore.
 

--- a/docs/02-getting-started.mdx
+++ b/docs/02-getting-started.mdx
@@ -25,6 +25,7 @@ Brigade.
 - Backbone requires jQuery and underscore.
 - brigade.ReactMounter should work with any version of Backbone or Marionette
 - brigade.ReactView only supports Marionette 1.8.*
+- brigade.StatefulReactView only supports Marionette 1.8.*
 - React 15 and 16 are supported
 
 ## Insallation
@@ -38,34 +39,37 @@ npm i -S @helpscout/brigade
 
 ## Choose Your Flavor
 
-Brigade includes two higher-order functions (HOF) to help you integrate React
+Brigade includes three higher-order functions (HOF) to help you integrate React
 into your Backbone or Marionette apps.
 
-Both HOFS have the same API. Invoke the HOF with a View to create a new View
-that is enhanced with React capabilities.
+All three HOFs have the same API. Invoke the HOF with a View to create a new View that is
+enhanced with React capabilities.
 
 ```
 import Marionette from 'backbone.marionette'
-import {ReactMounter, ReactView} from '@helpscout/brigade'
+import {ReactMounter, ReactView, StatefulReactView } from '@helpscout/brigade'
 
 const ViewA = ReactMounter(Marionette.ItemView)
 const ViewB = ReactView(Marionette.ItemView)
+const ViewC = StatefulReactView(Marionette.ItemView)
 ```
 
 The signature of each HOF is the same, but the differences end there. They
-accomodate two distinct means of integrating React into a Backbone or
+accomodate three distinct means of integrating React into a Backbone or
 Marionette application.
 
-1. ReactMounter mounts React components inside a Backbone or Marionette View.
+1. ReactMounter mounts one or more React components inside a Backbone or Marionette View.
 2. ReactView uses React as the template layer in a Marionette ItemView.
+3. StatefulReactView also uses React as the template layer in a Marionette ItemView and it expects to be passed a 
+   Redux store, which is smashed into a `<Provider>` that wraps the component returned from `template()`.
 
-It is recommended that you learn about both of these HOFs and then choose the
+It is recommended that you learn all three of these HOFs and then choose the
 one that best suits the task at hand.
 
 ## Migrating from 0.x to 1.x
 
 Brigade 1.0.0 drops the default export. Users need to pick a flavour, importing
-ReactMounter or ReactView, depending on their use case.
+ReactMounter, ReactView, or StatefulReactView depending on their use case.
 
 If you are moving from 0.x to 1.x you should replace:
 
@@ -88,7 +92,17 @@ ReactMounter builds on the default export from Brigade 0.3. The API for the
 about the differences and update your Views accordingingly. The new API is
 simpler, more flexible, and more powerful.
 
+For Marionette users specifically, you may find the new ReactView useful as a
+simple replacement for the template layer in Marionette.ItemView. You may also 
+find StatefulReactView useful as a replacement for the template layer
+in Marionette.ItemView which uses Redux as a store.
+
 ## Learn More
 
 - [ReactMounter](/react-mounter)
 - [ReactView](/react-view)
+- [StatefulReactView](/stateful-react-view)
+
+## Issues
+
+Report issues on Github at [https://github.com/helpscout/brigade/issues](https://github.com/helpscout/brigade/issues).

--- a/docs/02-getting-started.mdx
+++ b/docs/02-getting-started.mdx
@@ -13,12 +13,12 @@ Brigade.
 ### Peer Dependencies:
 
 - [Backbone](https://www.npmjs.com/package/backbone)
+- [Marionette](https://www.npmjs.com/package/backbone.marionette) (Optional)
 - [React](https://www.npmjs.com/package/react)
 - [React DOM](https://www.npmjs.com/package/react-dom)
-
-### Optional Peer Dependencies
-
-- [Marionette](https://www.npmjs.com/package/backbone.marionette)
+- [React Redux](https://www.npmjs.com/package/react-redux)
+- [Redux](https://www.npmjs.com/package/redux)
+- [Redux Thunk](https://www.npmjs.com/package/redux-thunk)
 
 ### Notes
 

--- a/docs/03-ReactMounter.mdx
+++ b/docs/03-ReactMounter.mdx
@@ -253,6 +253,43 @@ You will note in the above example, we do not need to remap the `addPerson`
 action. Because we used `store.getStatelessExternalActions()` the first
 argument will be the `person`, not the `state`.
 
+## Usage with Backbone Views
+
+While this library was designed to work with Marionette, `ReactMounter` is
+compatible with Backbone but it does require a bit of coercing. `ReactMounter`
+replies on a `render` event which Marionette implements in its views to know
+when it is safe to mount the React components. If you want to use this with
+Backbone views you can, but you will need to trigger a `render` event from 
+within your `render` method.
+
+For example:
+
+```
+import $ from 'jquery'
+import Backbone from 'backbone'
+import React from 'react'
+import { ReactMounter} from '@helpscout/brigade'
+
+const MyComponent = () => <div>Hello World</div>
+
+const AppView = ReactMounter(Backbone.View.extend({
+  el: $('#app'),
+
+  components: {
+    '#my-component': MyComponent
+  },
+
+  render() {
+    this.$el.html('<div id="my-component"></div>')
+    this.trigger('render')
+    return this
+  }
+}))
+
+const appView = new AppView()
+appView.render()
+```
+
 ## Ideal Use Case
 
 ReactMounter is ideally suited for mounting one or more complex React components

--- a/doczrc.js
+++ b/doczrc.js
@@ -1,8 +1,6 @@
 export default {
   title: 'Brigade',
   description: 'Backbone-controlled React Components',
-  indexHtml: 'public/index.html',
-  public: './public',
   themeConfig: {
     colors: {
       primary: '#22A1F0',

--- a/doczrc.js
+++ b/doczrc.js
@@ -1,6 +1,8 @@
 export default {
   title: 'Brigade',
-  description: 'Backbone-controlled React Component',
+  description: 'Backbone-controlled React Components',
+  indexHtml: 'public/index.html',
+  public: './public',
   themeConfig: {
     colors: {
       primary: '#22A1F0',

--- a/netlify.toml 
+++ b/netlify.toml 
@@ -8,3 +8,4 @@
   from = "/*"
   to = "/index.html"
   status = 200
+  force = false

--- a/netlify.toml 
+++ b/netlify.toml 
@@ -6,6 +6,5 @@
 # routing internally.
 [[redirects]]
   from = "/*"
-  to = "/index.html"
+  to = "/"
   status = 200
-  force = false

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   },
   "peerDependencies": {
     "backbone": "^1",
+    "backbone.marionette": ">= 1.8",
     "react": "^15 || ^16",
     "react-dom": "^15 || ^16",
     "react-redux": "^6.0.1",


### PR DESCRIPTION
This update improves the Getting Started docs which had no mention of `StatefulReactView`.  It also updates the Peer Dependencies for this project and includes usage instructions for Backbone views.

It also updates `netlify.toml` to fix a routing issue. Non-root URLs should be redirected to `/` and handled by the SPA.