### PR TITLE
Fix: jQuery XSS Security Vulnerability: CVE-2020-11023

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "jest-dom": "^3.0.0",
     "jest-jquery-matchers": "^2.1.0",
     "jest-util": "^23.4.0",
-    "jquery": "3.4.1",
+    "jquery": ">=3.5.0",
     "js-yaml": "3.13.1",
     "np": "3.0.4",
     "nyc": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@babel/core": "^7.1.6",
     "@helpscout/helix": "^0.1.0",
+    "@helpscout/hsds-illos": "^1.8.0",
     "@helpscout/hsds-react": "^2.8.4",
     "@helpscout/zero": "1.0.3",
     "@storybook/addon-links": "^4.1.12",


### PR DESCRIPTION
This update bumps the version of jQuery to `>= 3.5.0` because jQuery `< 3.5.0` had an XSS security vulnerability. See: https://github.com/advisories/GHSA-jpcq-cgw6-v4j6 for more details. Since jQuery was a development dependency and not included in the Brigade library, this security update is not critical.

This update also adds a new dependency: HSDS Illos. The Storybook uses an older version of HSDS React (V2) which requires HSDS Illos as a peer dependency. This new addition satisfied that requirement.

Neither of these changes impact the current version of the Brigade library on NPM. They do however constitute some improvements to this repository and the development environment.